### PR TITLE
Add required maintainer field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,7 @@
 name=TFL-Status
 version=1.0.1
 author=Dushyant Ahuja <dusht.ahuja@gmail.com>
+maintainer=Dushyant Ahuja <dusht.ahuja@gmail.com>
 sentence=A small library for an ESP8266 to pull tube status from the TFL API (work in progress)
 paragraph=A small library for an ESP8266 to pull tube status from the TFL API (work in progress).
 category=Communication


### PR DESCRIPTION
When the `maintainer` field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently with some IDE versions.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked (https://github.com/arduino/Arduino/issues/9073).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format